### PR TITLE
Some work for extending gasless to support DSR via CHAI

### DIFF
--- a/contracts/Gasless.sol
+++ b/contracts/Gasless.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.5.12;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
@@ -9,28 +9,34 @@ interface MCD {
     function transferFrom(address src, address dst, uint wad) external returns (bool);
 }
 
-interface UniswapExchange {
-    function tokenToEthTransferInput(
-        uint256 tokens_sold,
-        uint256 min_eth,
-        uint256 deadline,
-        address recipient
-    ) external returns (uint256  eth_bought);
+interface ICHAI {
+    function dai(address usr) external returns (uint);
+    function approve(address usr, uint wad) external returns (bool);
+    function move(address src, address dst, uint wad) external returns (bool);
+    function join(address dst, uint wad) external;
+    function draw(address src, uint wad) external;
 }
 
 contract Gasless {
     using SafeMath for uint;
 
-    uint MAX_UINT256 = 2**256-1;
     MCD MCDContract;
-    UniswapExchange UniswapExchangeContract;
+    ICHAI ICHAIContract;
+
     address relayer;
+
     bytes32 public DOMAIN_SEPARATOR;
     bytes32 public constant SEND_TYPEHASH = keccak256(
-        "Send(address relayer,address to,uint256 value,uint256 fee,uint256 gasprice,uint256 nonce,uint256 deadline)"
+        "Send(address to,uint256 value,uint256 nonce,uint256 fee,uint256 deadline,address relayer,uint256 gasprice)"
     );
-    bytes32 public constant SWAP_TYPEHASH = keccak256(
-        "Swap(address relayer,uint256 dai_sold,uint256 min_eth,uint256 fee,uint256 gasprice,uint256 nonce,uint256 deadline)"
+    bytes32 public constant JOIN_TYPEHASH = keccak256(
+        "Join(uint256 value,uint256 nonce,uint256 fee,uint256 deadline,address relayer,uint256 gasprice)"
+    );
+    bytes32 public constant EXIT_TYPEHASH = keccak256(
+        "Exit(address to,uint256 value,uint256 nonce,uint256 fee,uint256 deadline,address relayer,uint256 gasprice)"
+    );
+    bytes32 public constant EXIT_ALL_TYPEHASH = keccak256(
+        "ExitAll(address to,uint256 nonce,uint256 fee,uint256 deadline,address relayer,uint256 gasprice)"
     );
 
     event RelayerChange(address newRelayer);
@@ -42,9 +48,9 @@ contract Gasless {
         _;
     }
 
-    constructor(address initialRelayer, address MCDaddress, address UniswapExchangeAddress, uint chainId) public {
+    constructor(address initialRelayer, address MCDaddress, address ICHAIaddress, uint chainId) public {
         MCDContract = MCD(MCDaddress);
-        UniswapExchangeContract = UniswapExchange(UniswapExchangeAddress);
+        ICHAIContract = ICHAI(ICHAIaddress);
         relayer = initialRelayer;
         DOMAIN_SEPARATOR = keccak256(abi.encode(
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
@@ -53,7 +59,7 @@ contract Gasless {
             chainId,
             address(this)
         ));
-        approveUniswap();
+        approveChai();
     }
 
     function changeRelayer(address newRelayer) public onlyRelayer {
@@ -67,54 +73,91 @@ contract Gasless {
                 "\x19\x01",
                 DOMAIN_SEPARATOR,
                 keccak256(abi.encode(SEND_TYPEHASH,
-                                     relayer,
                                      to,
                                      value,
-                                     fee,
-                                     tx.gasprice,
                                      nonce,
-                                     deadline))
+                                     fee,
+                                     deadline,
+                                     relayer,
+                                     tx.gasprice))
         ));
         address from = ecrecover(digest, v, r, s);
         require(nonce == nonces[from], "Invalid nonce");
         nonces[from]++;
+
         MCDContract.transferFrom(from, to, value.sub(fee));
         MCDContract.transferFrom(from, msg.sender, fee);
     }
 
-    function daiToEthSwap(
-        uint dai_sold,
-        uint min_eth,
-        uint nonce,
-        uint fee,
-        uint deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) public onlyRelayer {
+    function join_chai(uint value, uint nonce, uint fee, uint deadline, uint8 v, bytes32 r, bytes32 s) public onlyRelayer {
         require(block.timestamp <= deadline, "Deadline expired");
         bytes32 digest = keccak256(abi.encodePacked(
                 "\x19\x01",
                 DOMAIN_SEPARATOR,
-                keccak256(abi.encode(SWAP_TYPEHASH,
-                                     relayer,
-                                     dai_sold,
-                                     min_eth,
-                                     fee,
-                                     tx.gasprice,
+                keccak256(abi.encode(JOIN_TYPEHASH,
+                                     value,
                                      nonce,
-                                     deadline))
+                                     fee,
+                                     deadline,
+                                     relayer,
+                                     tx.gasprice))
         ));
         address from = ecrecover(digest, v, r, s);
         require(nonce == nonces[from], "Invalid nonce");
         nonces[from]++;
+
+        MCDContract.transferFrom(from, address(this), value.sub(fee));
         MCDContract.transferFrom(from, msg.sender, fee);
-        MCDContract.transferFrom(from, address(this), dai_sold.sub(fee));
-        UniswapExchangeContract.tokenToEthTransferInput(dai_sold, min_eth, deadline, from);
+        ICHAIContract.join(from, value);
     }
 
-    function approveUniswap() public {
-        MCDContract.approve(address(UniswapExchangeContract), MAX_UINT256);
+    function exit_chai(address to, uint nonce, uint fee, uint deadline, uint8 v, bytes32 r, bytes32 s) public onlyRelayer {
+        require(block.timestamp <= deadline, "Deadline expired");
+        bytes32 digest = keccak256(abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(EXIT_ALL_TYPEHASH,
+                                     to,
+                                     nonce,
+                                     fee,
+                                     deadline,
+                                     relayer,
+                                     tx.gasprice))
+        ));
+        address from = ecrecover(digest, v, r, s);
+        require(nonce == nonces[from], "Invalid nonce");
+        nonces[from]++;
+
+        uint value = ICHAIContract.dai(from);
+        ICHAIContract.draw(from, value);
+        MCDContract.transfer(to, value.sub(fee));
+        MCDContract.transfer(msg.sender, fee);
     }
 
+    function draw_chai(address to, uint value, uint nonce, uint fee, uint deadline, uint8 v, bytes32 r, bytes32 s) public onlyRelayer {
+        require(block.timestamp <= deadline, "Deadline expired");
+        bytes32 digest = keccak256(abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(EXIT_TYPEHASH,
+                                     to,
+                                     value,
+                                     nonce,
+                                     fee,
+                                     deadline,
+                                     relayer,
+                                     tx.gasprice))
+        ));
+        address from = ecrecover(digest, v, r, s);
+        require(nonce == nonces[from], "Invalid nonce");
+        nonces[from]++;
+
+        ICHAIContract.draw(from, value);
+        MCDContract.transfer(to, value.sub(fee));
+        MCDContract.transfer(msg.sender, fee);
+    }
+
+    function approveChai() public {
+        MCDContract.approve(address(ICHAIContract), uint(-1)); // or 2**256-1
+    }
 }


### PR DESCRIPTION
@nourharidy following telegram conv, here is the pr

In my end, when playing with galess I didn't need UniswapExchange related feature at all so I simply delete it. I kind of swap UniswapExchange to CHAI and add some functions to:
- _create_ chai (dsr's token's representation) from dai `join_chain()`
- _exitAll_ chai to dai `exit_chai()` witch withdraw all user's compounding dsr to dai
- _exit_ `draw_chai()` witch withdraw a specific amount of user's chai to dai, but the `value` unit is in dai so that user know exactly what he get at the end.

I also modify SEND_TYPEHASH params order for consistency.

For the Gasless contract to work, it needs:
| Action    | Contract | holder  | spender |
|-----------|----------|---------|---------|
| permit()  | Dai      | EOA     | Gasless |
| permit()  | Chai     | EOA     | Gasless |
| approve() | Dai      | Gasless | Chai    |

The `approve()` is done on the constructor but the permit has to be done "manually" for each user

To clarify,  its still WIP and I got no intention to maintain it as I will use `ds-dach` but It was really nice to place with your contract for a good starting point!